### PR TITLE
Bug fix for userinfo and Sync issue

### DIFF
--- a/pennylane_support_backend/app/auth.py
+++ b/pennylane_support_backend/app/auth.py
@@ -145,13 +145,14 @@ def requires_auth(_fn=None, *, required_role: Optional[str] = None):
                     401,
                 )
 
-            g.current_user = {
+            ns = (NAMESPACE or "https://pennylane.app/").rstrip("/") + "/" 
+            g.current_user = {                                        
                 "sub": payload.get("sub"),
-                "email": payload.get("email"),
+                "email": payload.get(f"{ns}email") or payload.get("email"),
+                "name":  payload.get(f"{ns}name")  or payload.get("name"),
                 "nickname": payload.get("nickname"),
-                "name": payload.get("name"),
             }
-            g.roles = payload.get(f"{NAMESPACE}roles", [])
+            g.roles = payload.get(f"{ns}roles", []) 
 
             # If a role is required, verify it
             if required_role and required_role not in g.roles:

--- a/pennylane_support_backend/app/models/user.py
+++ b/pennylane_support_backend/app/models/user.py
@@ -1,5 +1,6 @@
 from app.extensions import db
 from sqlalchemy import func  
+from sqlalchemy.dialects import postgresql
 
 class User(db.Model):
     __tablename__ = "users"
@@ -8,7 +9,12 @@ class User(db.Model):
     username = db.Column(db.String(80), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
     name     = db.Column(db.String(120)) 
-    roles = db.Column(db.JSON, nullable=False, server_default='[]')
+    roles = db.Column(
+        postgresql.ARRAY(db.String),
+        nullable=False,
+        default=list,
+        server_default='{}'
+    )
     auth0_id = db.Column(db.String(255), unique=True, nullable=False) 
 
     def __repr__(self):

--- a/pennylane_support_frontend/src/app/TokenBridge.tsx
+++ b/pennylane_support_frontend/src/app/TokenBridge.tsx
@@ -3,13 +3,14 @@
 import { useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { setAccessToken } from '@/lib/apolloClient';
-
+import { useSyncUser } from '@/app/lib/useSyncUser';
 /**
  * Bridges Auth0 React SDK → Apollo header.
  * Mounts once inside <AuthProvider>.
  */
 export default function TokenBridge() {
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
+  useSyncUser();
 
   useEffect(() => {
     if (!isAuthenticated) {

--- a/pennylane_support_frontend/src/app/graphql/operations.ts
+++ b/pennylane_support_frontend/src/app/graphql/operations.ts
@@ -19,7 +19,7 @@ export const CONVERSATION_FIELDS = gql`
     challenge {
       id
       title
-    }
+    }     
     assignedSupport {            
       ...UserFields
     }
@@ -196,11 +196,20 @@ export const LIST_CHALLENGES_PAGED = gql`
 
 
 export const SYNC_USER = gql`
-  mutation SyncUser($e: String!, $n: String!) {
-  syncUser(email: $e, name: $n) {
-    ok
-    user { id email name }
+  mutation SyncUser(
+    $email: String!
+    $username: String!
+    $auth0Id: String!
+  ) {
+    syncUser(email: $email, username: $username, auth0Id: $auth0Id) {
+      ok
+      user {
+        id
+        email
+        username
+        name
+      }
+    }
   }
-}
 
 `;

--- a/pennylane_support_frontend/src/features/challenges/components/ChallengeCard.tsx
+++ b/pennylane_support_frontend/src/features/challenges/components/ChallengeCard.tsx
@@ -39,7 +39,7 @@ export const ChallengeCard: React.FC<Props> = ({ challenge }) => {
         {challenge.assignedSupport && (
           <Tag size="sm" mt={2} colorScheme="green">
             Assigned to{' '}
-            {challenge.assignedSupport.username ??
+            {challenge.assignedSupport.name ??
               challenge.assignedSupport.email}
           </Tag>
         )}

--- a/pennylane_support_frontend/src/features/conversations/components/ConversationCard.tsx
+++ b/pennylane_support_frontend/src/features/conversations/components/ConversationCard.tsx
@@ -53,7 +53,7 @@ export const ConversationCard: React.FC<Props> = ({
 
         {conversation.assignedSupport ? (
           <Tag size="sm" mt={2} colorScheme="green">
-            {`Assigned to ${conversation.assignedSupport.username ??
+            {`Assigned to ${conversation.assignedSupport.name ??
               conversation.assignedSupport.email
               }`}
           </Tag>

--- a/pennylane_support_frontend/src/features/conversations/components/ConversationFilters.tsx
+++ b/pennylane_support_frontend/src/features/conversations/components/ConversationFilters.tsx
@@ -81,7 +81,7 @@ export const ConversationFilters: React.FC<Props> = ({
         >
           {users.map((u) => (
             <option key={u.id} value={u.id}>
-              {u.username ?? u.email}
+              {u.name ?? u.email}
             </option>
           ))}
         </Select>

--- a/pennylane_support_frontend/src/types/domain.ts
+++ b/pennylane_support_frontend/src/types/domain.ts
@@ -2,6 +2,7 @@
 export interface SupportUser {
   id: number;
   username?: string;
+  name?: string;
   email?: string;
 }
 


### PR DESCRIPTION
1. The fix was to update our Auth0 PostLogin Action to explicitly add name and email as custom namespaced claims in the access token. Once we did that, the Python backend could read those claims directly from the token without needing to implement an OIDC userinfo fetch.
2. Made sure syn worked properly for userinfo.